### PR TITLE
add ca-certificates in Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,7 +15,7 @@
 FROM marketplace.gcr.io/google/debian11 AS build
 
 RUN apt-get update \
-    && apt-get install -y --no-install-recommends wget pkg-config zip g++ zlib1g-dev unzip python git patch \
+    && apt-get install -y --no-install-recommends wget pkg-config zip g++ zlib1g-dev unzip python git patch ca-certificates \
     && rm -rf /var/lib/apt/lists/*
 
 # Install bazel


### PR DESCRIPTION
Fix build error:

The command '/bin/sh -c wget -q -O /bazel-installer.sh https://github.com/bazelbuild/bazel/releases/download/4.2.1/bazel-4.2.1-installer-linux-x86_64.sh && chmod +x /bazel-installer.sh' returned a non-zero code: 5